### PR TITLE
Handle optional dependencies gracefully

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         reversion=['django-reversion'],
         debug=['django-debug-toolbar'],
     ),
-    entry_points = {
+    entry_points={
         'console_scripts': [
             'crudlfap = crudlfap_example.manage:main',
         ],

--- a/src/crudlfap_example/settings.py
+++ b/src/crudlfap_example/settings.py
@@ -16,6 +16,21 @@ import importlib
 
 def add_optional_dep(module: str, to: list=None,
                      before: str=None, after: str=None):
+    """
+    Adds an optional dependency
+
+    Add an optional dependency to the given `to` list, if it is resolvable by
+    the importer. If to is not given, it defaults to INSTALLED_APPS.
+
+    The module can be inserted at the right spot by using before or after
+    keyword arguments. If both are given, the gun is pointing at your feet
+    and before wins. If neither are given, the module is appended at the end.
+
+    :param module: module to add, as it would be added to the given `to` list
+    :param to: list to add the module to
+    :param before: module string as should be available in the to list.
+    :param after: module string as should be available in the to list.
+    """
     has_module = False
     if to is None:
         to = INSTALLED_APPS

--- a/src/crudlfap_example/settings.py
+++ b/src/crudlfap_example/settings.py
@@ -11,6 +11,35 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
+import importlib
+
+
+def add_optional_dep(module: str, before: str=None, after: str=None):
+    has_module = False
+    try:
+        importlib.__import__(module)
+    except ModuleNotFoundError:
+        pass
+    else:
+        has_module = True
+
+    if not has_module:
+        return
+
+    if not before and not after:
+        INSTALLED_APPS.append(module)
+        return
+
+    try:
+        if before:
+            pos = INSTALLED_APPS.index(before)
+        else:
+            pos = INSTALLED_APPS.index(after) + 1
+    except ValueError:
+        pass
+    else:
+        INSTALLED_APPS.insert(pos, module)
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -41,25 +70,19 @@ INSTALLED_APPS = [
     'crudlfap',
     'bootstrap3',
 
-    # CRUDLFA+ optionnal dependencies
-    'crudlfap_filtertables2',
-    'django_filters',
-    'django_tables2',
-    'dal',
-    'dal_select2',
-
     # CRUDLFA+ examples
     'crudlfap_example.artist',
     'crudlfap_example.song',
     'crudlfap_example.nondb',
 ]
 
-try:
-    import debug_toolbar
-except ImportError:
-    pass
-else:
-    INSTALLED_APPS.insert(5, 'debug_toolbar')
+# CRUDLFA+ optional dependencies
+add_optional_dep('debug_toolbar', after='django.contrib.staticfiles')
+add_optional_dep('crudlfap_filtertables2', before='crudlfap_example.artist')
+add_optional_dep('django_filters', before='crudlfap_example.artist')
+add_optional_dep('django_tables2', before='crudlfap_example.artist')
+add_optional_dep('dal', before='crudlfap_example.artist')
+add_optional_dep('dal_select2', before='crudlfap_example.artist')
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/src/crudlfap_example/settings.py
+++ b/src/crudlfap_example/settings.py
@@ -14,61 +14,6 @@ import os
 import importlib
 
 
-def add_optional_dep(module: str, to: list=None,
-                     before: str=None, after: str=None):
-    """
-    Adds an optional dependency
-
-    Add an optional dependency to the given `to` list, if it is resolvable by
-    the importer. If to is not given, it defaults to INSTALLED_APPS.
-
-    The module can be inserted at the right spot by using before or after
-    keyword arguments. If both are given, the gun is pointing at your feet
-    and before wins. If neither are given, the module is appended at the end.
-
-    :param module: module to add, as it would be added to the given `to` list
-    :param to: list to add the module to
-    :param before: module string as should be available in the to list.
-    :param after: module string as should be available in the to list.
-    """
-    has_module = False
-    if to is None:
-        to = INSTALLED_APPS
-
-    try:
-        importlib.__import__(module)
-    except ModuleNotFoundError:
-        mod_path, dot, cls = module.rpartition('.')
-        if not mod_path:
-            return
-        try:
-            mod = importlib.import_module(mod_path)
-        except ModuleNotFoundError:
-            return
-        else:
-            if hasattr(mod, cls):
-                has_module = True
-    else:
-        has_module = True
-
-    if not has_module:
-        return
-
-    if not before and not after:
-        to.append(module)
-        return
-
-    try:
-        if before:
-            pos = to.index(before)
-        else:
-            pos = to.index(after) + 1
-    except ValueError:
-        pass
-    else:
-        to.insert(pos, module)
-
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -105,12 +50,14 @@ INSTALLED_APPS = [
 ]
 
 # CRUDLFA+ optional dependencies
-add_optional_dep('debug_toolbar', after='django.contrib.staticfiles')
-add_optional_dep('crudlfap_filtertables2', before='crudlfap_example.artist')
-add_optional_dep('django_filters', before='crudlfap_example.artist')
-add_optional_dep('django_tables2', before='crudlfap_example.artist')
-add_optional_dep('dal', before='crudlfap_example.artist')
-add_optional_dep('dal_select2', before='crudlfap_example.artist')
+OPTIONAL_APPS = [
+    {'debug_toolbar': {'after': 'django.contrib.staticfiles'}},
+    {'crudlfap_filtertables2': {'before': 'crudlfap_example.artist'}},
+    {'django_filters': {'before': 'crudlfap_example.artist'}},
+    {'django_tables2': {'before': 'crudlfap_example.artist'}},
+    {'dal': {'before': 'crudlfap_example.artist'}},
+    {'dal_select2': {'before': 'crudlfap_example.artist'}},
+]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
@@ -121,9 +68,10 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
-add_optional_dep('debug_toolbar.middleware.DebugToolbarMiddleware',
-                 to=MIDDLEWARE)
 
+OPTIONAL_MIDDLEWARE = [
+    {'debug_toolbar.middleware.DebugToolbarMiddleware': {}}
+]
 INTERNAL_IPS = ('127.0.0.1',)
 
 ROOT_URLCONF = 'crudlfap_example.urls'
@@ -254,3 +202,100 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
 STATIC_URL = '/static/'
+
+
+def _resolve_module(module: str) -> bool:
+    """
+    Determines if a given module string can be resolved
+
+    Determine if the module referenced by string, can be imported by trying
+    an import in two ways:
+
+    - direct import of the module
+    - import of the module minus the last part, then see if the last part is
+      an attribute of the module.
+
+    Parts of course, are separated by dots.
+
+    :param module: module reference
+    :return: True if importable, False otherwise
+    """
+    has_module = False
+    try:
+        importlib.__import__(module)
+    except ModuleNotFoundError:
+        mod_path, dot, cls = module.rpartition('.')
+        if not mod_path:
+            return False
+        try:
+            mod = importlib.import_module(mod_path)
+        except ModuleNotFoundError:
+            return False
+        else:
+            if hasattr(mod, cls):
+                has_module = True
+    else:
+        has_module = True
+
+    return has_module
+
+
+def add_optional_dep(module: str, to: list = None, before: str = None,
+                     after: str = None):
+    """
+    Adds an optional dependency
+
+    Add an optional dependency to the given `to` list, if it is
+    resolvable by
+    the importer. If to is not given, it defaults to INSTALLED_APPS.
+
+    The module can be inserted at the right spot by using before or after
+    keyword arguments. If both are given, the gun is pointing at your feet
+    and before wins. If neither are given, the module is appended at the
+    end.
+
+    :param module: module to add, as it would be added to the given `to`
+    list
+    :param to: list to add the module to
+    :param before: module string as should be available in the to list.
+    :param after: module string as should be available in the to list.
+    """
+    if to is None:
+        to = INSTALLED_APPS
+
+    if not _resolve_module(module):
+        return
+
+    if not before and not after:
+        to.append(module)
+        return
+
+    try:
+        if before:
+            pos = to.index(before)
+        else:
+            pos = to.index(after) + 1
+    except ValueError:
+        pass
+    else:
+        to.insert(pos, module)
+
+
+def install_optional(source: list, target: list=None):
+    """
+    Install optional modules
+
+    :param source: modules to install
+    :param target: install into this list. Default: INSTALLED_APPS.
+    :return:
+    """
+    if not target:
+        target = INSTALLED_APPS
+    for app in source:
+        for ref, kwargs in app.items():
+            kwargs.setdefault('to', target)
+            add_optional_dep(ref, **kwargs)
+
+
+install_optional(OPTIONAL_APPS)
+install_optional(OPTIONAL_MIDDLEWARE, MIDDLEWARE)

--- a/src/crudlfap_example/settings.py
+++ b/src/crudlfap_example/settings.py
@@ -36,7 +36,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
-    'debug_toolbar',
 
     # CRUDLFA+ dependencies
     'crudlfap',
@@ -54,6 +53,13 @@ INSTALLED_APPS = [
     'crudlfap_example.song',
     'crudlfap_example.nondb',
 ]
+
+try:
+    import debug_toolbar
+except ImportError:
+    pass
+else:
+    INSTALLED_APPS.insert(5, 'debug_toolbar')
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
 [testenv:checkqa]
 commands =
     flake8 --show-source --max-complexity=7 --filename=test_*.py .
-    flake8 --show-source --exclude migrations,settings --max-complexity=4 --ignore=E305 crudlfap_example
+    flake8 --show-source --exclude migrations,settings --max-complexity=7 --ignore=E305 crudlfap_example
     flake8 --show-source --max-complexity=7 --ignore=F401 crudlfap/crudlfap.py
     flake8 --show-source --exclude */*/migrations --max-complexity=8 --exclude crudlfap/crudlfap.py,test_*.py crudlfap
 deps =


### PR DESCRIPTION
The `crudlfap` command uses `manage.py` from the example project. This has a number of packages marked as optional by default enabled.
Handle this more gracefully so that the command starts.